### PR TITLE
Remove Invalid Aria-Label From SVG Text Elements

### DIFF
--- a/player/js/elements/svgElements/SVGTextElement.js
+++ b/player/js/elements/svgElements/SVGTextElement.js
@@ -96,7 +96,6 @@ SVGTextLottieElement.prototype.buildNewText = function () {
     this.layerElement.setAttribute('font-style', fStyle);
     this.layerElement.setAttribute('font-weight', fWeight);
   }
-  this.layerElement.setAttribute('aria-label', documentData.t);
 
   var letters = documentData.l || [];
   var usesGlyphs = !!this.globalData.fontManager.chars;


### PR DESCRIPTION
As @woutthielemans mentioned in #2944, the group element doesn't have a valid role compatible with `aria-label`, which actually potentially adds more confusion, and as was in their case, most cases I've run into where there are text elements in the SVG, they only add confusion, not clarity, when read without a description, and in at least VoiceOver, the `title` and `desc` are ignored if elements in the SVG contain `aria-label`. So instead of a screen reader reading a helpful title and description, it'll read random words without context. As was mentioned, you could make this label optional, but given that its presence isn't valid in the first place, the best and simplest solution is to remove it altogether. This commit removes the line that adds that attribute.